### PR TITLE
A few more pixels to accommodate current save bookmark page

### DIFF
--- a/Source/popup.html
+++ b/Source/popup.html
@@ -115,9 +115,9 @@
                 chrome.tabs.getSelected(null , function(tab) {
 					var selection = "";
 					if (selection.length > 0)
-						window.open("https://pinboard.in/add?jump=close&url=" + encodeURIComponent(tab.url) + "&title=" + encodeURIComponent(tab.title) + "&description=" + encodeURIComponent(selection.substr(0, 256)), "pinboad.in", "location=no,links=no,scrollbars=no,toolbar=no,width=700,height=350");
+						window.open("https://pinboard.in/add?jump=close&url=" + encodeURIComponent(tab.url) + "&title=" + encodeURIComponent(tab.title) + "&description=" + encodeURIComponent(selection.substr(0, 256)), "pinboad.in", "location=no,links=no,scrollbars=no,toolbar=no,width=700,height=360");
 					else
-						window.open("https://pinboard.in/add?jump=close&url=" + encodeURIComponent(tab.url) + "&title=" + encodeURIComponent(tab.title), "pinboad.in", "location=no,links=no,scrollbars=no,toolbar=no,width=700,height=350");
+						window.open("https://pinboard.in/add?jump=close&url=" + encodeURIComponent(tab.url) + "&title=" + encodeURIComponent(tab.title), "pinboad.in", "location=no,links=no,scrollbars=no,toolbar=no,width=700,height=360");
                 });
             }
 


### PR DESCRIPTION
I think the pinboard site added some text to the save bookmark page that
made the page scroll at the current height:

  http://i.imgur.com/gcj9o.png

Just bumping up the dimensions so there are no scroll bars
