### PR TITLE
Restricts permission to activeTab and pinboard

### DIFF
--- a/background.js
+++ b/background.js
@@ -87,16 +87,7 @@ function popularBookmarks() {
 }
 
 function saveBookmark() {
-	chrome.tabs.getSelected(null , function(tab) {
-		chrome.tabs.sendRequest(tab.id, {method: "getSelection"}, function(response) {
-			if (null != response && null != response.data && 0 < response.data.length) {
-				window.open("https://pinboard.in/add?jump=close&url=" + encodeURIComponent(tab.url) + "&title=" + encodeURIComponent(tab.title) + "&description=" + encodeURIComponent(response.data.substr(0, 256)), "pinboad.in", "location=no,links=no,scrollbars=no,toolbar=no,width=700,height=550");
-			} 
-			else {
-				window.open("https://pinboard.in/add?jump=close&url=" + encodeURIComponent(tab.url) + "&title=" + encodeURIComponent(tab.title), "pinboad.in", "location=no,links=no,scrollbars=no,toolbar=no,width=700,height=550");
-			} 
-		});
-    });
+	chrome.tabs.executeScript({file: "save_bookmark.js"});
 }
 
 function readLater() {

--- a/manifest.json
+++ b/manifest.json
@@ -14,12 +14,6 @@
 			"background.js"
 		]
     },
-    "content_scripts": [{
-    	"matches": ["http://*/*", "https://*/*"],
-    	"run_at": "document_start",
-    	"js": ["selection.js"],
-    	"all_frames": true
-    }],
     "browser_action": {
         "default_icon": "icon_19_light.png",
         "default_title": "Pinboard",
@@ -27,10 +21,9 @@
     },
     "options_page": "options.html",
     "permissions": [
-        "tabs",
+        "activeTab",
         "notifications",
-        "http://*/*",
-        "https://*/*"
+        "https://*.pinboard.in/*"
     ],
     "web_accessible_resources": [
         "icon_19_dark.png",

--- a/popup.js
+++ b/popup.js
@@ -58,7 +58,10 @@ function addMenuItems() {
 					addMenuItem(allMenuItems[menuItem], function () { chrome.extension.getBackgroundPage().popularBookmarks(); closePopups(); });
 				} 
 				else if ("saveBookmark" == menuItem) {
-					addMenuItem(allMenuItems[menuItem], function () { chrome.extension.getBackgroundPage().saveBookmark(); closePopups(); });
+					addMenuItem(allMenuItems[menuItem], function () { 
+						closePopups(); // close popup first, to avoid blocking saveBookmark:
+						chrome.extension.getBackgroundPage().saveBookmark(); 
+					});
 				} 
 				else if ("readLater" == menuItem) {
 					addMenuItem(allMenuItems[menuItem], function () { chrome.extension.getBackgroundPage().readLater(); closePopups(); });

--- a/save_bookmark.js
+++ b/save_bookmark.js
@@ -1,0 +1,7 @@
+window.open(
+	'https://pinboard.in/add' 
+	+ '?url='+encodeURIComponent(location.href)	
+	+ '&title='+encodeURIComponent(document.title)
+	+ '&description='+encodeURIComponent(window.getSelection().toString()),
+	'Pinboard',
+	'toolbar=no,width=700,height=350');

--- a/selection.js
+++ b/selection.js
@@ -1,8 +1,0 @@
-chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
-	if ("getSelection" == request.method) {
-		sendResponse({data: window.getSelection().toString()});
-	} 
-	else {
-		sendResponse({}); // snub them.
-	}
-});


### PR DESCRIPTION
Hey, thanks for writing this extension. I really liked it, but wanted a few extra features so I went ahead and implemented them yesterday. 

This commit changes the permissions asked by the extension to just the active tab and https://pinboard, instead of the scary all-data-on-all-websites. The current text selection is now fetched by injecting a script [to just the active tab] through chrome.tabs.executeScript, instead of using content_scripts. 

I made a few other commits (that I haven't included in this request) that add the following features:
- Add the current text selection in the description field for read-later.
- Option to automatically fill in popular and recommended tags when marking a page as read-later.
- A keyboard command to save the current page without opening up a popup (basically, read-later without setting the toRead field. I wanted an easy alternative for Chrome's Ctrl+D shortcut that saved directly to Pinboard.)
- A better way of using chrome.tabs.executeScript for getting the tab details, instead of loading up a different file.

Let me know if you're interested; I'll send a pull request for them as well.
